### PR TITLE
Add upper limit for python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
     install_requires = requirements,
     extras_require={ 'dev': dev_requirements },
     dependency_links = cfg.get('dep_links','').split(),
-    python_requires  = '>=' + cfg['min_python'],
+    python_requires  = '>=' + cfg['min_python'] + ', <=' + py_versions[-1],
     long_description = open('README.md', encoding='utf-8').read(),
     long_description_content_type = 'text/markdown',
     zip_safe = False,


### PR DESCRIPTION
If you try to install it from python 3.12 it throws an error like this:
```
Collecting widgetsnbextension==4.0.10 (from pisces==0.0.1)
  Using cached widgetsnbextension-4.0.10-py3-none-any.whl.metadata (1.6 kB)
Collecting wrapt==1.16.0 (from pisces==0.0.1)
  Using cached wrapt-1.16.0-cp312-cp312-win_amd64.whl.metadata (6.8 kB)
Collecting zipp==3.18.1 (from pisces==0.0.1)
  Using cached zipp-3.18.1-py3-none-any.whl.metadata (3.5 kB)
INFO: pip is looking at multiple versions of pisces to determine which version is compatible with other requirements. This could take a while.
ERROR: Package 'pisces' requires a different Python: 3.12.3 not in '<3.11,>=3.10'
```